### PR TITLE
Fix vocabulary page component to get random term

### DIFF
--- a/src/app/vocabulary/page.tsx
+++ b/src/app/vocabulary/page.tsx
@@ -1,13 +1,48 @@
-import { notFound, redirect } from "next/navigation";
+"use client";
 
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import {
+  Alert,
+  AlertActions,
+  AlertDescription,
+  AlertTitle,
+  Button,
+} from "@/components";
 import { getRandomTerm } from "@/features/term/term.repository";
 
-export default async function Terms() {
-  const terms = await getRandomTerm();
+export default function Terms() {
+  const [error, setError] = useState<string | null>(null);
 
-  if (!terms) {
-    notFound();
-  }
+  const router = useRouter();
 
-  redirect(`/vocabulary/${terms.id}`);
+  useEffect(() => {
+    async function redirectRandom() {
+      const term = await getRandomTerm();
+      if (term) {
+        router.replace(`/vocabulary/${term.id}`);
+      } else {
+        setError("No terms found, please add term before use quiz.");
+      }
+    }
+    if (!error) {
+      redirectRandom();
+    }
+  }, [router, error]);
+
+  return (
+    <Alert open={!!error} onClose={() => setError(null)}>
+      <AlertTitle>Something went wrong :(</AlertTitle>
+      <AlertDescription>{error}</AlertDescription>
+      <AlertActions>
+        <Button plain onClick={() => router.push("/")}>
+          Go home
+        </Button>
+        <Button onClick={() => router.push("/vocabulary/add")}>
+          Add new term
+        </Button>
+      </AlertActions>
+    </Alert>
+  );
 }


### PR DESCRIPTION
The vocabulary page component has been updated to fix an issue where it was not correctly retrieving a random term. The component now uses the `useRouter` hook from `next/navigation` and the `getRandomTerm` function from the `term.repository` module to fetch a random term. If no terms are found, an error message is displayed with options to go back to the home page or add a new term.