### PR TITLE
Disable autocomplete for answer field in vocabulary page

### DIFF
--- a/src/app/vocabulary/[id]/page.tsx
+++ b/src/app/vocabulary/[id]/page.tsx
@@ -21,6 +21,7 @@ export default async function Vocabulary({
             name={SUBMISSION_ANSWER_KEY}
             placeholder="Type your answer here"
             autoFocus
+            autoComplete="off"
           />
         </Field>
       </form>


### PR DESCRIPTION
This pull request fixes an issue where autocomplete was enabled for the answer field in the vocabulary page. Autocomplete has been disabled by adding the `autoComplete="off"` attribute to the answer field.