### PR TITLE
Update Dockerfile to use different user and group IDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY ./public ./public
 COPY ./src ./src
 COPY ./.env ./.env
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN addgroup --system --gid 1003 nodejs
+RUN adduser --system --uid 976 nextjs
 
 RUN chown -R nextjs:nodejs /app
 USER nextjs


### PR DESCRIPTION
This pull request updates the Dockerfile to use different user and group IDs. Previously, the user and group IDs were set to 1001 and 976 respectively. Now, they are set to 1003 and 976. This change ensures better security and isolation within the container.