### PR TITLE
Add session check in vocabulary page

### DIFF
--- a/src/app/vocabulary/page.tsx
+++ b/src/app/vocabulary/page.tsx
@@ -10,12 +10,24 @@ import {
   AlertTitle,
   Button,
 } from "@/components";
+import { getSessionId } from "@/features/session/session.action";
 import { getRandomTerm } from "@/features/term/term.repository";
 
 export default function Terms() {
+  const [sid, setSessionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const router = useRouter();
+
+  useEffect(() => {
+    async function checkSession() {
+      const sid = await getSessionId();
+      setSessionId(sid);
+    }
+    if (!sid) {
+      checkSession();
+    }
+  }, [sid]);
 
   useEffect(() => {
     async function redirectRandom() {
@@ -26,10 +38,10 @@ export default function Terms() {
         setError("No terms found, please add term before use quiz.");
       }
     }
-    if (!error) {
+    if (sid && !error) {
       redirectRandom();
     }
-  }, [router, error]);
+  }, [sid, router, error]);
 
   return (
     <Alert open={!!error} onClose={() => setError(null)}>


### PR DESCRIPTION
This pull request adds a session check in the vocabulary page. It introduces a new function `checkSession()` that retrieves the session ID using `getSessionId()` and sets it in the state. The function is called in the `useEffect()` hook to check if the session ID is null and then fetches a random term using `getRandomTerm()`. If no terms are found, an error message is displayed. This change ensures that the vocabulary page only redirects to a random term if a valid session ID is available.