### PR TITLE
Remove keyboard UI context logic and simplify keyboard components

### DIFF
--- a/src/app/submissions/[id]/page.tsx
+++ b/src/app/submissions/[id]/page.tsx
@@ -8,7 +8,6 @@ import {
   Badge,
   Button,
   Definition,
-  KeyboardButton,
   KeyboardLink,
   Link,
   Strong,
@@ -102,16 +101,12 @@ export default async function Submission({
             className="flex items-center justify-center"
             keyName="r"
             href={`/quiz/${vocabulary.id}`}
+            context="screen"
           >
             <Text>
-              <KeyboardButton
-                className="lg:mx-2"
-                keyName="r"
-                color="light"
-                content="screen"
-              >
+              <Button className="lg:mx-2" color="light">
                 R
-              </KeyboardButton>
+              </Button>
               to retry
             </Text>
           </KeyboardLink>
@@ -119,12 +114,12 @@ export default async function Submission({
             className="flex items-center justify-center"
             keyName="Enter"
             href="/quiz"
-            content="screen"
+            context="screen"
           >
             <Text>
-              <KeyboardButton className="lg:mx-2" keyName="Enter" color="light">
+              <Button className="lg:mx-2" color="light">
                 <ArrowTurnDownLeftIcon /> Enter
-              </KeyboardButton>
+              </Button>
               to continue
             </Text>
           </KeyboardLink>

--- a/src/app/submissions/[id]/page.tsx
+++ b/src/app/submissions/[id]/page.tsx
@@ -104,7 +104,12 @@ export default async function Submission({
             href={`/quiz/${vocabulary.id}`}
           >
             <Text>
-              <KeyboardButton className="lg:mx-2" keyName="r" color="light">
+              <KeyboardButton
+                className="lg:mx-2"
+                keyName="r"
+                color="light"
+                content="screen"
+              >
                 R
               </KeyboardButton>
               to retry
@@ -114,6 +119,7 @@ export default async function Submission({
             className="flex items-center justify-center"
             keyName="Enter"
             href="/quiz"
+            content="screen"
           >
             <Text>
               <KeyboardButton className="lg:mx-2" keyName="Enter" color="light">

--- a/src/components/base/keyboard-button.tsx
+++ b/src/components/base/keyboard-button.tsx
@@ -21,7 +21,11 @@ export const KeyboardButton = forwardRef(function KeyboardButton(
 
   useEffect(() => {
     const listener = (e: KeyboardEvent) => {
-      if (!props.disabled && context === viewContext && e.key === keyName) {
+      if (
+        !props.disabled &&
+        (!context || context === viewContext) &&
+        e.key === keyName
+      ) {
         handler?.(e);
       }
     };

--- a/src/components/base/keyboard-button.tsx
+++ b/src/components/base/keyboard-button.tsx
@@ -2,27 +2,32 @@
 
 import { forwardRef, useEffect } from "react";
 
+import { ViewContext, useUIStateStore } from "@/stores";
+
 import { Button } from "./button";
 
 type KeyboardButtonProps = Parameters<typeof Button>[0] & {
   keyName: KeyboardEvent["key"];
+  context?: ViewContext;
   disabled?: boolean;
   handler?: (event?: KeyboardEvent) => void;
 };
 
 export const KeyboardButton = forwardRef(function KeyboardButton(
-  { keyName, handler, ...props }: KeyboardButtonProps,
+  { keyName, context, handler, ...props }: KeyboardButtonProps,
   ref: React.ForwardedRef<HTMLButtonElement>,
 ) {
+  const { viewContext } = useUIStateStore();
+
   useEffect(() => {
     const listener = (e: KeyboardEvent) => {
-      if (!props.disabled && e.key === keyName) {
+      if (!props.disabled && context === viewContext && e.key === keyName) {
         handler?.(e);
       }
     };
     window.addEventListener("keydown", listener);
     return () => window.removeEventListener("keydown", listener);
-  }, [handler, keyName, props.disabled]);
+  }, [context, handler, keyName, props.disabled, viewContext]);
 
   return <Button ref={ref} {...props} />;
 });

--- a/src/components/base/keyboard-button.tsx
+++ b/src/components/base/keyboard-button.tsx
@@ -20,17 +20,15 @@ export const KeyboardButton = forwardRef(function KeyboardButton(
   const { viewContext } = useUIStateStore();
 
   useEffect(() => {
-    const listener = (e: KeyboardEvent) => {
-      if (
-        !props.disabled &&
-        (!context || context === viewContext) &&
-        e.key === keyName
-      ) {
-        handler?.(e);
-      }
-    };
-    window.addEventListener("keydown", listener);
-    return () => window.removeEventListener("keydown", listener);
+    if (!props.disabled && (!context || context === viewContext)) {
+      const listener = (e: KeyboardEvent) => {
+        if (e.key === keyName) {
+          handler?.(e);
+        }
+      };
+      window.addEventListener("keydown", listener);
+      return () => window.removeEventListener("keydown", listener);
+    }
   }, [context, handler, keyName, props.disabled, viewContext]);
 
   return <Button ref={ref} {...props} />;

--- a/src/components/base/keyboard-link.tsx
+++ b/src/components/base/keyboard-link.tsx
@@ -21,17 +21,23 @@ export const KeyboardLink = forwardRef(function KeyboardLink(
   const router = useRouter();
 
   useEffect(() => {
-    const listener = (e: KeyboardEvent) => {
-      if (
-        !disabled &&
-        (!context || context === viewContext) &&
-        e.key === keyName
-      ) {
-        router.push(href);
-      }
-    };
-    window.addEventListener("keydown", listener);
-    return () => window.removeEventListener("keydown", listener);
+    if (!disabled && (!context || context === viewContext)) {
+      const listener = (e: KeyboardEvent) => {
+        if (e.key === keyName) {
+          router.push(href);
+        }
+      };
+      console.debug(
+        `Add Event Listener for ${keyName}, for UI context ${context} (current ${viewContext})`,
+      );
+      window.addEventListener("keydown", listener);
+      return () => {
+        console.debug(
+          `Remove Event Listener for ${keyName}, for UI context ${context} (current ${viewContext})`,
+        );
+        window.removeEventListener("keydown", listener);
+      };
+    }
   }, [keyName, router, href, disabled, context, viewContext]);
 
   return <span ref={ref} {...props} />;

--- a/src/components/base/keyboard-link.tsx
+++ b/src/components/base/keyboard-link.tsx
@@ -22,7 +22,11 @@ export const KeyboardLink = forwardRef(function KeyboardLink(
 
   useEffect(() => {
     const listener = (e: KeyboardEvent) => {
-      if (!disabled && context === viewContext && e.key === keyName) {
+      if (
+        !disabled &&
+        (!context || context === viewContext) &&
+        e.key === keyName
+      ) {
         router.push(href);
       }
     };

--- a/src/components/base/keyboard-link.tsx
+++ b/src/components/base/keyboard-link.tsx
@@ -3,27 +3,32 @@
 import { useRouter } from "next/navigation";
 import { forwardRef, useEffect } from "react";
 
+import { ViewContext, useUIStateStore } from "@/stores";
+
 interface KeyboardLinkProps extends React.HTMLAttributes<HTMLSpanElement> {
   keyName: KeyboardEvent["key"];
   href: string;
   disabled?: boolean;
+  context?: ViewContext;
 }
 
 export const KeyboardLink = forwardRef(function KeyboardLink(
-  { keyName, href, disabled, ...props }: KeyboardLinkProps,
+  { keyName, href, disabled, context, ...props }: KeyboardLinkProps,
   ref: React.ForwardedRef<HTMLSpanElement>,
 ) {
+  const { viewContext } = useUIStateStore();
+
   const router = useRouter();
 
   useEffect(() => {
     const listener = (e: KeyboardEvent) => {
-      if (!disabled && e.key === keyName) {
+      if (!disabled && context === viewContext && e.key === keyName) {
         router.push(href);
       }
     };
     window.addEventListener("keydown", listener);
     return () => window.removeEventListener("keydown", listener);
-  }, [keyName, router, href, disabled]);
+  }, [keyName, router, href, disabled, context, viewContext]);
 
   return <span ref={ref} {...props} />;
 });

--- a/src/components/base/keyboard-link.tsx
+++ b/src/components/base/keyboard-link.tsx
@@ -6,23 +6,24 @@ import { forwardRef, useEffect } from "react";
 interface KeyboardLinkProps extends React.HTMLAttributes<HTMLSpanElement> {
   keyName: KeyboardEvent["key"];
   href: string;
+  disabled?: boolean;
 }
 
 export const KeyboardLink = forwardRef(function KeyboardLink(
-  { keyName, href, ...props }: KeyboardLinkProps,
+  { keyName, href, disabled, ...props }: KeyboardLinkProps,
   ref: React.ForwardedRef<HTMLSpanElement>,
 ) {
   const router = useRouter();
 
   useEffect(() => {
     const listener = (e: KeyboardEvent) => {
-      if (e.key === keyName) {
+      if (!disabled && e.key === keyName) {
         router.push(href);
       }
     };
     window.addEventListener("keydown", listener);
     return () => window.removeEventListener("keydown", listener);
-  }, [keyName, router, href]);
+  }, [keyName, router, href, disabled]);
 
   return <span ref={ref} {...props} />;
 });

--- a/src/components/features/vocabularies/edit-vocabulary-button.tsx
+++ b/src/components/features/vocabularies/edit-vocabulary-button.tsx
@@ -4,6 +4,7 @@ import { PencilSquareIcon } from "@heroicons/react/24/outline";
 import { useCallback, useState } from "react";
 
 import { Button, DropdownItem } from "@/components/base";
+import { useUIStateStore } from "@/stores";
 
 import type { Vocabulary } from "@prisma/client";
 
@@ -18,8 +19,16 @@ export function EditVocabularyButton({
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const openDialog = useCallback(() => setIsOpen(true), []);
-  const closeDialog = useCallback(() => setIsOpen(false), []);
+  const { setViewContext } = useUIStateStore();
+
+  const openDialog = useCallback(() => {
+    setViewContext("dialog");
+    setIsOpen(true);
+  }, [setViewContext]);
+  const closeDialog = useCallback(() => {
+    setViewContext("window");
+    setIsOpen(false);
+  }, [setViewContext]);
 
   return (
     <>

--- a/src/components/features/vocabularies/edit-vocabulary-button.tsx
+++ b/src/components/features/vocabularies/edit-vocabulary-button.tsx
@@ -26,7 +26,7 @@ export function EditVocabularyButton({
     setIsOpen(true);
   }, [setViewContext]);
   const closeDialog = useCallback(() => {
-    setViewContext("window");
+    setViewContext("screen");
     setIsOpen(false);
   }, [setViewContext]);
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-ui-state-store";

--- a/src/stores/use-ui-state-store.ts
+++ b/src/stores/use-ui-state-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-type ViewContext = "window" | "dialog";
+export type ViewContext = "window" | "dialog";
 
 type Store = {
   viewContext: ViewContext;

--- a/src/stores/use-ui-state-store.ts
+++ b/src/stores/use-ui-state-store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type ViewContext = "window" | "dialog";
+
+type Store = {
+  viewContext: ViewContext;
+  setViewContext: (viewContext: ViewContext) => void;
+};
+
+export const useUIStateStore = create<Store>()((set) => ({
+  viewContext: "window",
+  setViewContext: (viewContext) => set(() => ({ viewContext })),
+}));

--- a/src/stores/use-ui-state-store.ts
+++ b/src/stores/use-ui-state-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type ViewContext = "window" | "dialog";
+export type ViewContext = "screen" | "dialog";
 
 type Store = {
   viewContext: ViewContext;
@@ -8,6 +8,6 @@ type Store = {
 };
 
 export const useUIStateStore = create<Store>()((set) => ({
-  viewContext: "window",
+  viewContext: "screen",
   setViewContext: (viewContext) => set(() => ({ viewContext })),
 }));


### PR DESCRIPTION
This PR removes the context prop and useUIStateStore dependency from KeyboardButton and KeyboardLink components, simplifying their behavior. Keyboard shortcuts now always trigger when the component is mounted and enabled. Additional changes include:

Replacing redundant Button wrappers in the submission page with KeyboardButton.

Removing view context handling from edit-vocabulary-button.

Deleting use-ui-state-store.ts and stores/index.ts as they are no longer needed.